### PR TITLE
Update generate-a-new-key-pair.md

### DIFF
--- a/sdks-and-apis/sdks/keys/generate-a-new-key-pair.md
+++ b/sdks-and-apis/sdks/keys/generate-a-new-key-pair.md
@@ -80,7 +80,7 @@ System.out.println("public = " + publicKey);
 {% tab title="JavaScript" %}
 ```javascript
 const privateKey = PrivateKey.generateECDSA();
-const publicKey = privateKey.publicKey();
+const publicKey = privateKey.publicKey;
 
 console.log("private = " + privateKey);
 console.log("public = " + publicKey);


### PR DESCRIPTION
The old JavaScript code would give the error "publicKey is not a function". This is because publicKey is not a method, but is an attribute of the privateKey object. The example code in JavaScript was fixed.