### PR TITLE
Update generate-a-new-key-pair.md

### DIFF
--- a/sdks-and-apis/sdks/keys/generate-a-new-key-pair.md
+++ b/sdks-and-apis/sdks/keys/generate-a-new-key-pair.md
@@ -18,8 +18,8 @@ Create a new _**ED25519**_ key pair used to sign transactions and queries on the
 PrivateKey privateKey = PrivateKey.generateED25519();
 PublicKey publicKey = privateKey.getPublicKey();
 
-System.out.println("private = " + privateKey);
-System.out.println("public = " + publicKey);
+System.out.println("private key = " + privateKey);
+System.out.println("public key = " + publicKey);
 ```
 {% endtab %}
 
@@ -28,8 +28,8 @@ System.out.println("public = " + publicKey);
 const privateKey = await PrivateKey.generateED25519Async();
 const publicKey = privateKey.publicKey;
 
-console.log("private = " + privateKey);
-console.log("public = " + publicKey);
+console.log("private key = " + privateKey);
+console.log("public key = " + publicKey);
 ```
 {% endtab %}
 
@@ -42,8 +42,8 @@ if err != nil {
 
 publicKey := privateKey.PublicKey()
 
-fmt.Printf("private = %v\n", privateKey)
-fmt.Printf("public = %v\n", publicKey)
+fmt.Printf("private key = %v\n", privateKey)
+fmt.Printf("public key = %v\n", publicKey)
 ```
 {% endtab %}
 {% endtabs %}
@@ -72,8 +72,8 @@ Create a new _**ECDSA**_ (secp256k1) key pair used to sign transactions and quer
 PrivateKey privateKey = PrivateKey.generateECDSA();
 PublicKey publicKey = privateKey.getPublicKey();
 
-System.out.println("private = " + privateKey);
-System.out.println("public = " + publicKey);
+System.out.println("private key = " + privateKey);
+System.out.println("public key = " + publicKey);
 ```
 {% endtab %}
 
@@ -82,8 +82,8 @@ System.out.println("public = " + publicKey);
 const privateKey = PrivateKey.generateECDSA();
 const publicKey = privateKey.publicKey;
 
-console.log("private = " + privateKey);
-console.log("public = " + publicKey);
+console.log("private key = " + privateKey);
+console.log("public key = " + publicKey);
 ```
 {% endtab %}
 
@@ -96,8 +96,8 @@ if err != nil {
 
 publicKey := privateKey.PublicKey()
 
-fmt.Printf("private = %v\n", privateKey)
-fmt.Printf("public = %v\n", publicKey)
+fmt.Printf("private key = %v\n", privateKey)
+fmt.Printf("public key = %v\n", publicKey)
 ```
 {% endtab %}
 {% endtabs %}
@@ -105,6 +105,6 @@ fmt.Printf("public = %v\n", publicKey)
 **Sample Output:**
 
 ```
-private = 302e020100300506032b657004220420b9c3ebac81a72aafa5490cc78111643d016d311e60869436fbb91c73307ed35a 
-public = 302a300506032b65700321001a5a62bb9f35990d3fea1a5bb7ef6f1df0a297697adef1e04510c9d4ecc5db3f
+private key = 302e020100300506032b657004220420b9c3ebac81a72aafa5490cc78111643d016d311e60869436fbb91c73307ed35a 
+public key = 302a300506032b65700321001a5a62bb9f35990d3fea1a5bb7ef6f1df0a297697adef1e04510c9d4ecc5db3f
 ```


### PR DESCRIPTION
Fixed ECDSA Javascript sample code to refer to publicKey as an attribute and not a function. 
Edited all print statements in sample code to include the word "key" and match the provided Sample Output. 

Signed-off-by J Builds jaydav95@outlook.com